### PR TITLE
Fix typo in SAML template and tidy up build files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ info:
 	@echo "make builddeb     - build .deb file locally"
 
 ifndef VERSION
-        $(error VERSION not set. Set VERSION to build like VERSION=1.7)
+	$(error VERSION not set. Set VERSION to build like VERSION=1.7)
 	$(error This is a VERSION number is a github tag!)
 endif
 #VERSION=1.3~dev5
@@ -32,7 +32,7 @@ builddeb-current:
 	make select-conffiles
 	mkdir -p DEBUILD/privacyidea-ucs-saml.org
 	cp -r ${SRCDIRS} DEBUILD/privacyidea-ucs-saml.org || true
-	# We need to touch this, so that our config files 
+	# We need to touch this, so that our config files
 	# are written to /etc
 	(cd DEBUILD; tar -zcf privacyidea-ucs-saml_${VERSION}.orig.tar.gz --exclude=privacyidea.org/debian privacyidea-ucs-saml.org)
 	################# Build

--- a/conffiles-v1.9/etc/simplesamlphp/metadata/97saml20-idp-hosted.php
+++ b/conffiles-v1.9/etc/simplesamlphp/metadata/97saml20-idp-hosted.php
@@ -22,7 +22,7 @@ uidKey = configRegistry.get('privacyidea/saml/uidkey', 'uid')
 
 enabled = configRegistry.get('privacyidea/saml/enable', 'false')
 
-if enabled == 'authsource' or configRegistry.is_true('privacyidea/saml/enabled'):
+if enabled == 'authsource' or configRegistry.is_true('privacyidea/saml/enable'):
     print("$metadata['{entity_id}']['auth'] = 'privacyidea';".format(entity_id=entity_id))
 elif enabled == 'authproc':
     print("$metadata['{entity_id}']['authproc'] = array(".format(entity_id=entity_id))

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,18 @@ Source: privacyidea-ucs-saml
 Maintainer: NetKnights GmbH  <info@netknights.it>
 Section: admin
 Priority: optional
-Build-Depends: debhelper (>= 7.4.3), univention-config-dev
+Build-Depends-Indep:
+ debhelper (>= 7.4.3),
+ univention-config-dev,
 Standards-Version: 3.9.5
 
 Package: privacyidea-ucs-saml
 Architecture: all
-Depends: ${misc:Depends}, univention-saml, php-curl
+Depends:
+ php-curl,
+ univention-saml,
+ ${misc:Depends},
 Description: privacyIDEA Plugin for simpleSAMLphp
  privacyIDEA: identity, multifactor authentication, authorization.
  This adds two factor authentication with privacyIDEA to the
  SAML SSO for Univention Corprate Server.
- 

--- a/debian/privacyidea-ucs-saml.install
+++ b/debian/privacyidea-ucs-saml.install
@@ -1,7 +1,7 @@
-simplesamlphp-module-privacyidea/lib/                              /usr/share/simplesamlphp/modules/privacyidea/
-simplesamlphp-module-privacyidea/dictionaries/				/usr/share/simplesamlphp/modules/privacyidea/
+simplesamlphp-module-privacyidea/default-enable			/usr/share/simplesamlphp/modules/privacyidea/
+simplesamlphp-module-privacyidea/dictionaries/			/usr/share/simplesamlphp/modules/privacyidea/
+simplesamlphp-module-privacyidea/docs/privacyidea.md	/usr/share/simplesamlphp/modules/privacyidea/docs/
+simplesamlphp-module-privacyidea/lib/					/usr/share/simplesamlphp/modules/privacyidea/
 simplesamlphp-module-privacyidea/templates/				/usr/share/simplesamlphp/modules/privacyidea/
-simplesamlphp-module-privacyidea/www/					/usr/share/simplesamlphp/modules/privacyidea/
-simplesamlphp-module-privacyidea/default-enable				/usr/share/simplesamlphp/modules/privacyidea/
-simplesamlphp-module-privacyidea/docs/privacyidea.md			/usr/share/simplesamlphp/modules/privacyidea/docs/
 simplesamlphp-module-privacyidea/themes/				/usr/share/simplesamlphp/modules/privacyidea/
+simplesamlphp-module-privacyidea/www/					/usr/share/simplesamlphp/modules/privacyidea/


### PR DESCRIPTION
During debugging of the Privacy-SAML App v2.1.2 I stumbled over a typo in the template which may lead to undesired behaviour in case the UCR variable `privacyidea/saml/enable` is set to ''true" instead of `autsource` or `authproc`

Furthermore, I used `ucslint` (internal) and `wrap-and-sort -ast` to tidy up the build files a bit.