### PR TITLE
fix for Univention 5. Missing typeOfTokenToEnroll UCR variable

### DIFF
--- a/conffiles-template/etc/simplesamlphp/metadata/97saml20-idp-hosted.php
+++ b/conffiles-template/etc/simplesamlphp/metadata/97saml20-idp-hosted.php
@@ -18,6 +18,7 @@ SSO = configRegistry.get('privacyidea/saml/SSO', 'false')
 preferredTokenType = configRegistry.get('privacyidea/saml/preferredTokenType', 'otp')
 doEnrollToken = configRegistry.get('privacyidea/saml/doEnrollToken', 'false')
 tokenType = configRegistry.get('privacyidea/saml/tokenType', '')
+typeOfTokenToEnroll = configRegistry.get('privacyidea/saml/typeOfTokenToEnroll', '')
 tryFirstAuthentication = configRegistry.get('privacyidea/saml/tryFirstAuthentication', 'false')
 tryFirstAuthPass = configRegistry.get('privacyidea/saml/tryFirstAuthentication', '')
 
@@ -56,13 +57,14 @@ elif enabled == 'authproc':
         'preferredTokenType' => '{preferredTokenType}',
         'doEnrollToken' => '{doEnrollToken}',
         'tokenType' => '{tokenType}',
+        'typeOfTokenToEnroll' => '{typeOfTokenToEnroll}',
         'tryFirstAuthentication' => '{tryFirstAuthentication}',
         'tryFirstAuthPass' => '{tryFirstAuthPass}',
 """.format(privacyideaServerURL=privacyideaServerURL, realm=realm, uidKey=uidKey, sslVerifyHost=sslVerifyHost.lower(),
             sslVerifyPeer=sslVerifyPeer.lower(), enabledPath=enabledPath, enabledKey=enabledKey,
             authenticationFlow=authenticationFlow, serviceAccount=serviceAccount, servicePass=servicePass,
             otpFieldHint=otpFieldHint, SSO=SSO.lower(), preferredTokenType=preferredTokenType,
-            doEnrollToken=doEnrollToken, tokenType=tokenType,
+            doEnrollToken=doEnrollToken, tokenType=tokenType, typeOfTokenToEnroll=typeOfTokenToEnroll,
             tryFirstAuthentication=tryFirstAuthentication.lower(), tryFirstAuthPass=tryFirstAuthPass))
 
     if excludeClientIPs != '':


### PR DESCRIPTION
This variable exists in UCS5 UCR configs in `privacyidea/saml/typeOfTokenToEnroll`

but missing from the template.

Token enrolment does not work. This variable is checked in:

[/usr/share/simplesamlphp/modules/privacyidea/lib/Auth/Process/PrivacyideaAuthProc.php](https://github.com/NetKnights-GmbH/privacyidea-ucs-saml/tree/e8d7ff5bed2fc9fff6a72390fae30d77715a9335/simplesamlphp-module-privacyidea/lib/Auth/Process)

https://github.com/NetKnights-GmbH/privacyidea-ucs-saml/blob/e8d7ff5bed2fc9fff6a72390fae30d77715a9335/simplesamlphp-module-privacyidea/lib/Auth/Process/PrivacyideaAuthProc.php#L192